### PR TITLE
1.1.1

### DIFF
--- a/src/Files/Paths.php
+++ b/src/Files/Paths.php
@@ -2,8 +2,13 @@
 
 namespace bultonFr\Utils\Files;
 
+use Exception;
+
 class Paths
 {
+    const EXCEP_ABS_REL_SAME_PATH = 203001;
+    const EXCEP_ABS_REL_NOT_COMMON = 203002;
+
     /**
      * Resolve the relative path for two abslute path
      *
@@ -17,7 +22,10 @@ class Paths
         string $destPath
     ): string {
         if ($srcPath === $destPath) {
-            return '';
+            throw new Exception(
+                'source path and dest path are same.',
+                static::EXCEP_ABS_REL_SAME_PATH
+            );
         }
 
         //Remove first slash to not have a empty string for key 0
@@ -52,7 +60,10 @@ class Paths
 
         //First item of paths is not same, no common between path.
         if ($notSameIdx === 0) {
-            return $destPath;
+            throw new Exception(
+                'source path and dest path have no common point at the beginning.',
+                static::EXCEP_ABS_REL_NOT_COMMON
+            );
         }
 
         $nbDestItem = count($destPathEx) - 1;

--- a/src/Files/Tests/FileManager.php
+++ b/src/Files/Tests/FileManager.php
@@ -117,6 +117,8 @@ class FileManager extends atoum
         ;
 
         $this->assert('test Files\FileManager::createSymlink - creation success')
+            ->if($this->handler->clear())
+            ->then
             ->if($fileExistsMock->returnedValues = [false, true])
             ->and($this->function->symlink = true)
             ->then
@@ -140,7 +142,55 @@ class FileManager extends atoum
                 ])
         ;
 
+        $this->assert('test Files\FileManager::createSymlink - creation success with relative path')
+            ->if($this->handler->clear())
+            ->then
+            ->if($fileExistsMock->returnedValues = [false, true])
+            ->and($fileExistsMock->resetIdx())
+            ->and($this->function->symlink = true)
+            ->then
+            ->variable($this->mock->createSymlink('/var/www/target/file', '/var/www/dest/file'))
+                ->isNull()
+            ->function('symlink')
+                ->wasCalledWithArguments('../target/file', '/var/www/dest/file')
+                    ->once()
+            ->boolean($this->handler->hasDebug('FileManager - Create symlink'))
+                ->isTrue()
+            ->boolean($this->handler->hasDebug('FileManager - Create symlink - Use relative path'))
+                ->isTrue()
+            ->array($records = $this->handler->getRecords())
+            ->array($context = reset($records)['context'])
+                ->isEqualTo([
+                    'linkTarget' => '/var/www/target/file',
+                    'linkFile'   => '/var/www/dest/file'
+                ])
+            ->array($context = end($records)['context'])
+                ->isEqualTo([
+                    'target' => '../target/file'
+                ])
+        ;
+
+        $this->assert('test Files\FileManager::createSymlink - creation success without relative path')
+            ->if($this->handler->clear())
+            ->then
+            ->if($fileExistsMock->returnedValues = [false, true])
+            ->and($fileExistsMock->resetIdx())
+            ->and($this->function->symlink = true)
+            ->then
+            ->variable($this->mock->createSymlink('/var/www/target/file', '/var/www/dest/file', false))
+                ->isNull()
+            ->function('symlink')
+                ->wasCalledWithArguments('/var/www/target/file', '/var/www/dest/file')
+                    ->once()
+            ->boolean($this->handler->hasDebug('FileManager - Create symlink'))
+                ->isTrue()
+            ->boolean($this->handler->hasDebug('FileManager - Create symlink - Use relative path'))
+                ->isFalse()
+        ;
+
         $this->assert('test Files\FileManager::createSymlink - creation failed - link file exist')
+            ->if($this->handler->clear())
+            ->then
             ->if($fileExistsMock->returnedValues = [true, true])
             ->and($fileExistsMock->resetIdx())
             ->and($this->function->symlink = true)
@@ -160,6 +210,8 @@ class FileManager extends atoum
         ;
 
         $this->assert('test Files\FileManager::createSymlink - creation failed - target file not exist')
+            ->if($this->handler->clear())
+            ->then
             ->if($fileExistsMock->returnedValues = [false, false])
             ->and($fileExistsMock->resetIdx())
             ->and($this->function->symlink = true)
@@ -179,6 +231,8 @@ class FileManager extends atoum
         ;
 
         $this->assert('test Files\FileManager::createSymlink - creation failed - symlink call failed')
+            ->if($this->handler->clear())
+            ->then
             ->if($fileExistsMock->returnedValues = [false, true])
             ->and($fileExistsMock->resetIdx())
             ->and($this->function->symlink = false)

--- a/src/Files/Tests/Paths.php
+++ b/src/Files/Tests/Paths.php
@@ -13,19 +13,23 @@ class Paths extends atoum
     public function testAbsoluteToRelative()
     {
         $this->assert('test Files\FileManager::absoluteToRelative - same path')
-            ->string(TestedPaths::absoluteToRelative(
-                '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src',
-                '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src'
-            ))
-                ->isEmpty()
+            ->exception(function () {
+                TestedPaths::absoluteToRelative(
+                    '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src',
+                    '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src'
+                );
+            })
+                ->hasCode(TestedPaths::EXCEP_ABS_REL_SAME_PATH)
         ;
 
         $this->assert('test Files\FileManager::absoluteToRelative - no common path')
-            ->string(TestedPaths::absoluteToRelative(
-                '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src',
-                '/home/myWebsite/v1.0/app/modules/bfw-sql'
-            ))
-                ->isEqualTo('/home/myWebsite/v1.0/app/modules/bfw-sql')
+            ->exception(function () {
+                TestedPaths::absoluteToRelative(
+                    '/var/www/myWebsite/v1.0/vendor/bulton-fr/bfw-sql/src',
+                    '/home/myWebsite/v1.0/app/modules/bfw-sql'
+                );
+            })
+                ->hasCode(TestedPaths::EXCEP_ABS_REL_NOT_COMMON)
         ;
 
         $this->assert('test Files\FileManager::absoluteToRelative - common path')


### PR DESCRIPTION
* Files\Paths::absoluteToRelative : Now throw an Exception if the relative path cannot be defined
* FileManager::createSymlink : Use relative path by default